### PR TITLE
Refactor token endpoint in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -10,13 +10,26 @@ Before you begin, you'll need an OpenAI API key - [create one in the dashboard h
 cp .env.example .env
 ```
 
-Running this application locally requires [Node.js](https://nodejs.org/) to be installed. Install dependencies for the application with:
+Running this application locally requires [Node.js](https://nodejs.org/) and [Python](https://www.python.org/) to be installed.
+Install dependencies for the frontend with:
 
 ```bash
 npm install
 ```
 
-Start the application server with:
+Install Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Build the React frontend:
+
+```bash
+npm run build:client
+```
+
+Start the development server with:
 
 ```bash
 npm run dev
@@ -24,7 +37,7 @@ npm run dev
 
 This should start the console application on [http://localhost:3000](http://localhost:3000).
 
-This application is a minimal template that uses [express](https://expressjs.com/) to serve the React frontend contained in the [`/client`](./client) folder. The server is configured to use [vite](https://vitejs.dev/) to build the React frontend.
+This application is a minimal template that uses [Express](https://expressjs.com/) to serve the React frontend contained in the [`/client`](./client) folder. The token generation endpoint is implemented in Python (`token.py`). The frontend is built with [Vite](https://vitejs.dev/).
 
 This application shows how to send and receive Realtime API events over the WebRTC data channel and configure client-side function calling. You can also view the JSON payloads for client and server events using the logging panel in the UI.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==1.0.1
+httpx==0.27.0

--- a/server.js
+++ b/server.js
@@ -1,11 +1,11 @@
 import express from "express";
 import fs from "fs";
 import { createServer as createViteServer } from "vite";
+import { execFile } from "child_process";
 import "dotenv/config";
 
 const app = express();
 const port = process.env.PORT || 3000;
-const apiKey = process.env.OPENAI_API_KEY;
 
 // Configure Vite middleware for React client
 const vite = await createViteServer({
@@ -14,30 +14,23 @@ const vite = await createViteServer({
 });
 app.use(vite.middlewares);
 
-// API route for token generation
-app.get("/token", async (req, res) => {
-  try {
-    const response = await fetch(
-      "https://api.openai.com/v1/realtime/sessions",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-realtime-preview-2024-12-17",
-          voice: "verse",
-        }),
-      },
-    );
-
-    const data = await response.json();
-    res.json(data);
-  } catch (error) {
-    console.error("Token generation error:", error);
-    res.status(500).json({ error: "Failed to generate token" });
-  }
+// API route for token generation using Python script
+app.get("/token", (req, res) => {
+  execFile("python3", ["token.py"], { env: process.env }, (err, stdout, stderr) => {
+    if (err) {
+      console.error("Token generation error:", err);
+      console.error(stderr);
+      res.status(500).json({ error: "Failed to generate token" });
+      return;
+    }
+    try {
+      const data = JSON.parse(stdout);
+      res.json(data);
+    } catch (e) {
+      console.error("Token parse error:", e);
+      res.status(500).json({ error: "Failed to generate token" });
+    }
+  });
 });
 
 // Render the React client

--- a/token.py
+++ b/token.py
@@ -1,0 +1,30 @@
+import os
+import json
+import asyncio
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+API_KEY = os.getenv("OPENAI_API_KEY")
+
+async def main():
+    if not API_KEY:
+        print(json.dumps({"error": "Missing OPENAI_API_KEY"}))
+        return
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.openai.com/v1/realtime/sessions",
+                headers={
+                    "Authorization": f"Bearer {API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={"model": "gpt-4o-realtime-preview-2024-12-17", "voice": "verse"},
+            )
+            resp.raise_for_status()
+            print(resp.text)
+    except Exception:
+        print(json.dumps({"error": "Failed to generate token"}))
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- restore `server.js` Express server for serving the frontend
- move OpenAI token generation logic into `token.py`
- call the Python script from the Node endpoint
- update README to describe Node+Python setup
- adjust dependencies and scripts

## Testing
- `npm run lint` *(fails to find eslint config)*